### PR TITLE
fix: arredondamento no cálculo de total de páginas

### DIFF
--- a/src/pages/Feed/index.js
+++ b/src/pages/Feed/index.js
@@ -27,7 +27,7 @@ export default function Feed() {
     const data = await response.json();
 
     setLoading(false);
-    setTotal(Math.floor(totalItems / 4));
+    setTotal(Math.ceil(totalItems / 4));
     setPage(pageNumber + 1);
 
     setFeed(shouldRefresh ? data : [...feed, ...data]);


### PR DESCRIPTION

Quando o total de itens é um número impar, usar a função `Math.floor(x)` impede a exibição da última página. Ex:

```js
const totalItens = 21
const itensPorPagina = 5

Math.floor(totalItens / itensPorPagina) // retorna 4 páginas, deixando de exibir a página 5 com 1 item restante
```

`Math.ceil(x)` retorna o menor número inteiro maior ou igual a "x"

```js
const totalItens = 21
const itensPorPagina = 5

Math.floor(totalItens / itensPorPagina) // retorna 5 páginas, a última página com 1 item apenas
```